### PR TITLE
Fix Newton-Raphson tolerance condition

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ def newton_raphson(f, df, x0, tol=1e-6, max_iter=100):
             return None, iterations, "Derivada cero"
             
         x_new = x - fx / dfx
+        fx_new = f(x_new)
         error = abs(x_new - x)
         iterations.append({
             'iteration': i+1,
@@ -34,8 +35,8 @@ def newton_raphson(f, df, x0, tol=1e-6, max_iter=100):
             'x_new': x_new,
             'error': error
         })
-        
-        if error < tol or abs(fx) < tol:
+
+        if error < tol or abs(fx_new) < tol:
             return x_new, iterations, None
             
         x = x_new


### PR DESCRIPTION
## Summary
- Correct Newton-Raphson loop to evaluate tolerance using the function value at the updated estimate.

## Testing
- `pytest -q`
- `python - <<'PY'
from app import newton_raphson
f=lambda x:x**2-2
df=lambda x:2*x
root, iterations, error_msg=newton_raphson(f, df, 1.0, tol=1e-6)
print('root:', root)
print('error_msg:', error_msg)
print('iterations:', iterations[-1])
PY`


------
https://chatgpt.com/codex/tasks/task_e_6892a8066d608328a9a62f9bc99c6c92