### PR TITLE
Prevent validation on unselected methods

### DIFF
--- a/app.py
+++ b/app.py
@@ -196,14 +196,13 @@ def index():
             function_expression = request.form.get("function", "x**2 - 2")
             derivative_expression = request.form.get("derivative", "2*x")
             edo_expression = request.form.get("edo", "-2*y")
-            
-            # Crear funciones
+
+            # Crear función principal
             f = lambda x: eval(function_expression, {'x': x, **safe_dict})
-            df = lambda x: eval(derivative_expression, {'x': x, **safe_dict})
-            f_edo = lambda t, y: eval(edo_expression, {'t': t, 'y': y, **safe_dict})
-            
+
             # Procesar métodos seleccionados
             if 'newton' in request.form:
+                df = lambda x: eval(derivative_expression, {'x': x, **safe_dict})
                 x0 = float(request.form["newton_x0"])
                 tol = float(request.form.get("newton_tol", 1e-6))
                 root, iterations, error_msg = newton_raphson(f, df, x0, tol)
@@ -213,7 +212,7 @@ def index():
                     'error': abs(f(root)) if root is not None else None,
                     'error_msg': error_msg
                 }
-                
+
             if 'bisection' in request.form:
                 a = float(request.form["bisection_a"])
                 b = float(request.form["bisection_b"])
@@ -262,6 +261,7 @@ def index():
                 }
                 
             if 'euler' in request.form:
+                f_edo = lambda t, y: eval(edo_expression, {'t': t, 'y': y, **safe_dict})
                 y0 = float(request.form["euler_y0"])
                 t0 = float(request.form["euler_t0"])
                 tn = float(request.form["euler_tn"])

--- a/templates/index.html
+++ b/templates/index.html
@@ -584,7 +584,16 @@
                 icon.classList.replace('fa-chevron-up', 'fa-chevron-down');
             }
         }
-        
+
+        // Enable or disable inputs based on checkbox state
+        function toggleInputs(method) {
+            const checkbox = document.getElementById(method);
+            const inputs = document.querySelectorAll(`#${method}-content input:not([type=checkbox])`);
+            inputs.forEach(input => {
+                input.disabled = !checkbox.checked;
+            });
+        }
+
         // Initialize sections
         document.addEventListener('DOMContentLoaded', function() {
             const sections = ['newton', 'bisection', 'secant', 'regula_falsi', 'trapezoidal', 'euler', 'error_calc'];
@@ -592,6 +601,11 @@
                 const content = document.getElementById(`${section}-content`);
                 if (content) {
                     content.style.display = 'block';
+                    toggleInputs(section);
+                    const checkbox = document.getElementById(section);
+                    if (checkbox) {
+                        checkbox.addEventListener('change', () => toggleInputs(section));
+                    }
                 }
             });
         });


### PR DESCRIPTION
## Summary
- Disable input fields for numerical methods unless their checkbox is selected
- Evaluate derivative and ODE expressions only when their methods run

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6892aa8ed654832887130f02f068aaf4